### PR TITLE
chore: dependency cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-      "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.0",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -773,22 +763,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
-      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        }
-      }
-    },
     "@babel/preset-env": {
       "version": "7.7.6",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
@@ -904,108 +878,6 @@
         "qrcode": "^1.4.4"
       }
     },
-    "@dashevo/dapi-client": {
-      "version": "github:dashevo/dapi-client#646009998ff61d1834a4c30de789649767172b5e",
-      "from": "github:dashevo/dapi-client#v0.12-dev",
-      "requires": {
-        "@babel/polyfill": "^7.8.3",
-        "@dashevo/dapi-grpc": "~0.12.1",
-        "@dashevo/dash-spv": "^1.1.6",
-        "@dashevo/dashcore-lib": "~0.18.0",
-        "@dashevo/dpp": "~0.12.0-dev.7",
-        "axios": "^0.19.2",
-        "cbor": "^5.0.1",
-        "lodash": "^4.17.15",
-        "lowdb": "^1.0.0"
-      },
-      "dependencies": {
-        "@babel/polyfill": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.7.tgz",
-          "integrity": "sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@dashevo/dapi-grpc": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.12.1.tgz",
-          "integrity": "sha512-pABiI6lGjtoFHy0Y18HFqPAk06gQArxCJgR1YBF2M+wZI3O38PROUkGHVb/29oZGR8sIB/b7siSypnczWmItiA==",
-          "requires": {
-            "@dashevo/grpc-common": "^0.2.0",
-            "google-protobuf": "^3.8.0",
-            "grpc": "^1.24.0",
-            "grpc-web": "^1.0.6",
-            "protobufjs": "^6.8.8"
-          }
-        },
-        "@dashevo/dpp": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.11.1.tgz",
-          "integrity": "sha512-H9UpWunAbL/IOWE1V1855UUxioqRUoStGbMFQ+5dAj/xLj3NXhQV3Y1wWn+Kvf6ExXkR1cmx2KintU8XpfeaHA==",
-          "requires": {
-            "@dashevo/dashcore-lib": "~0.18.0",
-            "ajv": "^6.10.2",
-            "bs58": "^4.0.1",
-            "cbor": "^5.0.1",
-            "json-schema-ref-parser": "^7.1.3",
-            "lodash.get": "^4.4.2",
-            "lodash.mergewith": "^4.6.2",
-            "lodash.set": "^4.3.2",
-            "multihashes": "^0.4.15"
-          }
-        },
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
-        "cbor": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.1.tgz",
-          "integrity": "sha512-l4ghwqioCyuAaD3LvY4ONwv8NMuERz62xjbMHGdWBqERJPygVmoFER1b4+VS6iW0rXwoVGuKZPPPTofwWOg3YQ==",
-          "requires": {
-            "bignumber.js": "^9.0.0",
-            "nofilter": "^1.0.3"
-          }
-        },
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        }
-      }
-    },
     "@dashevo/dapi-grpc": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.12.1.tgz",
@@ -1117,67 +989,6 @@
         }
       }
     },
-    "@dashevo/dpp": {
-      "version": "github:dashevo/js-dpp#48c9fda5cf958eb2046c8a5a98e09e78c1e8085f",
-      "from": "github:dashevo/js-dpp#v0.12-dev",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "^8.0.0",
-        "@dashevo/dashcore-lib": "~0.18.0",
-        "ajv": "^6.12.0",
-        "bs58": "^4.0.1",
-        "cbor": "^5.0.1",
-        "lodash.get": "^4.4.2",
-        "lodash.mergewith": "^4.6.2",
-        "lodash.set": "^4.3.2",
-        "multihashes": "^0.4.19"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
-        "cbor": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.1.tgz",
-          "integrity": "sha512-l4ghwqioCyuAaD3LvY4ONwv8NMuERz62xjbMHGdWBqERJPygVmoFER1b4+VS6iW0rXwoVGuKZPPPTofwWOg3YQ==",
-          "requires": {
-            "bignumber.js": "^9.0.0",
-            "nofilter": "^1.0.3"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-        },
-        "multihashes": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
-          "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        }
-      }
-    },
     "@dashevo/grpc-common": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.2.0.tgz",
@@ -1187,95 +998,6 @@
         "grpc": "^1.24.0",
         "grpc-health-check": "^1.7.0",
         "lodash.get": "^4.4.2"
-      }
-    },
-    "@dashevo/wallet-lib": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/wallet-lib/-/wallet-lib-4.1.1.tgz",
-      "integrity": "sha512-MLzLAgslutIip+36mBapto/IlWNhwY6gX7KgLS5/14CrG5F5I/9gnpfOVeW5FkqdpsHF6K/s4Q6WlZr4DpUt5Q==",
-      "requires": {
-        "@dashevo/dapi-client": "git+https://github.com/dashevo/dapi-client.git#temp/exclusion",
-        "@dashevo/dashcore-lib": "^0.17.9",
-        "@dashevo/dpp": "^0.7.2",
-        "axios": "^0.19.0",
-        "localforage": "^1.7.3",
-        "lodash": "^4.17.15",
-        "socket.io-client": "^2.2.0"
-      },
-      "dependencies": {
-        "@dashevo/dapi-client": {
-          "version": "git+https://github.com/dashevo/dapi-client.git#f8d764cb8f54a2bc411ebceccb24bad2236da407",
-          "from": "git+https://github.com/dashevo/dapi-client.git#temp/exclusion",
-          "requires": {
-            "@babel/polyfill": "^7.2.5",
-            "@dashevo/dapi-grpc": "^0.9.4",
-            "@dashevo/dash-spv": "^1.1.5",
-            "@dashevo/dashcore-lib": "^0.17.1",
-            "axios": "^0.19.0",
-            "lodash": "^4.17.11",
-            "lowdb": "^1.0.0"
-          }
-        },
-        "@dashevo/dapi-grpc": {
-          "version": "0.9.4",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.9.4.tgz",
-          "integrity": "sha512-jpOUxBrfFhL4LpF9r6v1QjAgzfMoxfyBvoPQftey3Qukl9jMtez/4NGoGousBLmF9dctLEjpRxNlBVuxEWooTQ==",
-          "requires": {
-            "@grpc/proto-loader": "^0.5.1",
-            "google-protobuf": "^3.8.0",
-            "grpc": "^1.22.0",
-            "grpc-web": "^1.0.5",
-            "lodash.snakecase": "^4.1.1",
-            "protobufjs": "^6.8.8"
-          }
-        },
-        "@dashevo/dashcore-lib": {
-          "version": "0.17.12",
-          "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-          "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
-          "requires": {
-            "@dashevo/x11-hash-js": "^1.0.2",
-            "bloom-filter": "^0.2.0",
-            "bn.js": "=4.11.8",
-            "bs58": "=4.0.1",
-            "elliptic": "=6.4.1",
-            "inherits": "=2.0.1",
-            "lodash": "^4.17.15",
-            "unorm": "^1.4.1"
-          }
-        },
-        "@dashevo/dpp": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.7.2.tgz",
-          "integrity": "sha512-qjAV3VMN1NXYfVLR12+45Csf0mmeuSMxRGpZZAg08HZSHuESV2R0d3f7ZgX81WdYhvG9OlKEAC5fMQA25JbFhA==",
-          "requires": {
-            "@dashevo/dashcore-lib": "^0.17.8",
-            "ajv": "^6.5.4",
-            "bs58": "^4.0.1",
-            "cbor": "^4.1.1",
-            "lodash.get": "^4.4.2",
-            "lodash.set": "^4.3.2"
-          }
-        },
-        "elliptic": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
       }
     },
     "@dashevo/x11-hash-js": {
@@ -1341,11 +1063,6 @@
         "cssnano-preset-default": "^4.0.0",
         "postcss": "^7.0.0"
       }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.1.tgz",
-      "integrity": "sha512-pu5fxkbLQWzRbBgfFbZfHXz0KlYojOfVdUhcNfy9lef8ZhBt0pckGr8g7zv4vPX4Out5vBNvqd/az4UaVWzZ9A=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -2268,11 +1985,6 @@
       "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
       "dev": true
     },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -2467,11 +2179,6 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "arraybuffer.slice": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-    },
     "ascli": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
@@ -2563,7 +2270,8 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2617,43 +2325,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -2747,11 +2418,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2821,11 +2487,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "base64-arraybuffer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -2844,14 +2505,6 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
-      }
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
       }
     },
     "bfj": {
@@ -2892,11 +2545,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "blob": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "bloom-filter": {
       "version": "0.2.0",
@@ -3355,11 +3003,6 @@
         "caller-callsite": "^2.0.0"
       }
     },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -3410,24 +3053,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "cbor": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
-      "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "commander": "^3.0.0",
-        "json-text-sequence": "^0.1",
-        "nofilter": "^1.0.3"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-        }
-      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -3956,21 +3581,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
     "compressible": {
       "version": "2.0.17",
@@ -4654,6 +4269,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -4933,11 +4549,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "depd": {
       "version": "1.1.2",
@@ -5222,51 +4833,6 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "engine.io-client": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
-      "integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "~4.1.0",
-        "engine.io-parser": "~2.2.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        },
-        "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -5908,125 +5474,6 @@
       "dev": true,
       "requires": {
         "original": "^1.0.0"
-      }
-    },
-    "evo-net-demo": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/evo-net-demo/-/evo-net-demo-0.1.0.tgz",
-      "integrity": "sha512-GybPAEfD+cMJet2k1XoA+pr3K+hG91VYEIHqIR3ygAMaNbzEY5I9YO0e1LomK7TkAKRPoZLynKpy41WkunYycw==",
-      "requires": {
-        "@dashevo/dapi-client": "^0.8.0-dev.14",
-        "@dashevo/dashcore-lib": "^0.18.0",
-        "@dashevo/dpp": "^0.10.0-dev.14",
-        "@dashevo/wallet-lib": "^4.1.1",
-        "bs58": "^4.0.1"
-      },
-      "dependencies": {
-        "@dashevo/dapi-client": {
-          "version": "0.8.0-dev.14",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.8.0-dev.14.tgz",
-          "integrity": "sha512-/dgZUDjHUHflxQS/q0N+nPW0LOnqH6PfN5QVwIR/KvJrWqwGlsyZgncVBECXOwvb8tsDPeRWlPgmzKknDHUA3g==",
-          "requires": {
-            "@babel/polyfill": "^7.2.5",
-            "@dashevo/dapi-grpc": "0.12.0-dev.10",
-            "@dashevo/dash-spv": "^1.1.5",
-            "@dashevo/dashcore-lib": "^0.17.11",
-            "axios": "^0.19.0",
-            "cbor": "^5.0.1",
-            "lodash": "^4.17.11",
-            "lowdb": "^1.0.0"
-          },
-          "dependencies": {
-            "@dashevo/dashcore-lib": {
-              "version": "0.17.12",
-              "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.17.12.tgz",
-              "integrity": "sha512-ZZFlWqzGTklW9uSsj4QNe1k3e5vrqDTfeaZwt2oU0dbmMltkFgNifx7Rq6ij5erRDKFoIkOG1ZM6Q4brc9eWUw==",
-              "requires": {
-                "@dashevo/x11-hash-js": "^1.0.2",
-                "bloom-filter": "^0.2.0",
-                "bn.js": "=4.11.8",
-                "bs58": "=4.0.1",
-                "elliptic": "=6.4.1",
-                "inherits": "=2.0.1",
-                "lodash": "^4.17.15",
-                "unorm": "^1.4.1"
-              }
-            }
-          }
-        },
-        "@dashevo/dapi-grpc": {
-          "version": "0.12.0-dev.10",
-          "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.12.0-dev.10.tgz",
-          "integrity": "sha512-xG06yulY1zCQFv8gBeCXwVthOKWgoPCUq6M/9v+wXZXdS3s3d4LWzQCW3nExpaMOdRuoc5OyrthYUZYWgF8rFw==",
-          "requires": {
-            "@dashevo/grpc-common": "^0.2.0",
-            "google-protobuf": "^3.8.0",
-            "grpc": "^1.24.0",
-            "grpc-web": "^1.0.6",
-            "protobufjs": "^6.8.8"
-          }
-        },
-        "@dashevo/dpp": {
-          "version": "0.10.0-dev.14",
-          "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.10.0-dev.14.tgz",
-          "integrity": "sha512-2SWpgkuyFO6010M0Sbq5UjaKc7fjxIslXUSZUg3w+vwUNY4npVVIMdhzD++vHi0fO7ZRbNdX0QESvx5hj/LxeQ==",
-          "requires": {
-            "@dashevo/dashcore-lib": "0.18.0",
-            "ajv": "^6.5.4",
-            "bs58": "^4.0.1",
-            "cbor": "^4.1.1",
-            "lodash.get": "^4.4.2",
-            "lodash.mergewith": "^4.6.2",
-            "lodash.set": "^4.3.2",
-            "multihashes": "^0.4.13"
-          },
-          "dependencies": {
-            "cbor": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/cbor/-/cbor-4.3.0.tgz",
-              "integrity": "sha512-CvzaxQlaJVa88sdtTWvLJ++MbdtPHtZOBBNjm7h3YKUHILMs9nQyD4AC6hvFZy7GBVB3I6bRibJcxeHydyT2IQ==",
-              "requires": {
-                "bignumber.js": "^9.0.0",
-                "commander": "^3.0.0",
-                "json-text-sequence": "^0.1",
-                "nofilter": "^1.0.3"
-              }
-            }
-          }
-        },
-        "cbor": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.0.1.tgz",
-          "integrity": "sha512-l4ghwqioCyuAaD3LvY4ONwv8NMuERz62xjbMHGdWBqERJPygVmoFER1b4+VS6iW0rXwoVGuKZPPPTofwWOg3YQ==",
-          "requires": {
-            "bignumber.js": "^9.0.0",
-            "nofilter": "^1.0.3"
-          }
-        },
-        "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
-        },
-        "elliptic": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-          "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
       }
     },
     "evp_bytestokey": {
@@ -7865,26 +7312,6 @@
         }
       }
     },
-    "has-binary2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "requires": {
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        }
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -8330,11 +7757,6 @@
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -8887,14 +8309,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
-    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -9042,21 +8456,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "requires": {
-        "immediate": "~3.0.5"
-      },
-      "dependencies": {
-        "immediate": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-        }
       }
     },
     "lines-and-columns": {
@@ -9586,14 +8985,6 @@
         }
       }
     },
-    "localforage": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
-      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
-      "requires": {
-        "lie": "3.1.1"
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -9656,11 +9047,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
     "lodash.transform": {
       "version": "4.6.0",
@@ -10172,34 +9558,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-      "requires": {
-        "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        }
-      }
-    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -10448,11 +9806,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
-    },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -10859,22 +10212,6 @@
       "dev": true,
       "requires": {
         "parse5": "^5.1.1"
-      }
-    },
-    "parseqs": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -12029,7 +11366,8 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -12844,69 +12182,6 @@
         }
       }
     },
-    "socket.io-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
-      "requires": {
-        "backo2": "1.0.2",
-        "base64-arraybuffer": "0.1.5",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
-        "engine.io-client": "~3.4.0",
-        "has-binary2": "~1.0.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "~3.3.0",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "sockjs": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
@@ -13615,11 +12890,6 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -14789,11 +14059,6 @@
         "async-limiter": "~1.0.0"
       }
     },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -14902,11 +14167,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "yorkie": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,10 @@
   },
   "dependencies": {
     "@chenfengyuan/vue-qrcode": "^1.0.2",
-    "@dashevo/dapi-client": "github:dashevo/dapi-client#v0.12-dev",
     "@dashevo/dashcore-lib": "^0.18.0",
-    "@dashevo/dpp": "github:dashevo/js-dpp#v0.12-dev",
     "brace": "^0.11.1",
     "core-js": "^3.4.3",
     "dash": "^2.0.0",
-    "evo-net-demo": "^0.1.0",
     "vue": "^2.6.11",
     "vue-router": "^3.1.3",
     "vue2-ace-editor": "0.0.15",


### PR DESCRIPTION
Pretty sure these dependencies are not used. DashJS should provide access to all the dapi-client/dpp stuff that is necessary. Removing them did not seem to be detrimental. :shrug: 